### PR TITLE
summarize tables in pipeline

### DIFF
--- a/docs/application_configuration.rst
+++ b/docs/application_configuration.rst
@@ -523,8 +523,9 @@ This setting lists the sub-modules or steps to be run by the PopulationSim orche
       - sub_balancing.geography=TRACT
       - sub_balancing.geography=TAZ
       - expand_households
-      - write_results
       - summarize
+      - write_results
+      - write_synthetic_population
   
     #resume_after: integerize_final_seed_weights	  
 	  

--- a/example_calm/configs/settings.yaml
+++ b/example_calm/configs/settings.yaml
@@ -92,6 +92,7 @@ control_file_name: controls.csv
 output_tables:
   action: include
   tables:
+    - summary_TAZ
     - expanded_household_ids
 
 
@@ -130,8 +131,8 @@ run_list:
     - sub_balancing.geography=TRACT
     - sub_balancing.geography=TAZ
     - expand_households
+    - summarize
     - write_tables
     - write_synthetic_population
-    - summarize
 
   #resume_after: expand_households

--- a/example_calm_repop/configs/settings.yaml
+++ b/example_calm_repop/configs/settings.yaml
@@ -61,6 +61,7 @@ output_tables:
   action: include
   tables:
     - expanded_household_ids
+    - summary_TAZ
 
 
 # Synthetic Population Output Specification
@@ -96,12 +97,9 @@ run_list:
     - repop_balancing
     # expand_households options are append or replace
     - expand_households.repop;append
+    - summarize.repop
     - write_synthetic_population.repop
     - write_tables.repop
 
   resume_after: summarize
-
-  
-
-
 

--- a/example_test/configs/settings.yaml
+++ b/example_test/configs/settings.yaml
@@ -59,9 +59,9 @@ run_list:
     - sub_balancing.geography=TRACT
     - sub_balancing.geography=TAZ
     - expand_households
+    - summarize
     - write_tables
     - write_synthetic_population
-    - summarize
 
   #resume_after: expand_households
 
@@ -92,10 +92,11 @@ repop_input_table_list:
 # if neither is specified, then no checkpointed tables will be written
 #
 output_tables:
-  action: skip
+  action: include
   tables:
-    - households
-    - persons
+    - summary_TAZ
+    - expanded_household_ids
+
 #
 #output_tables:
 #  action: include

--- a/example_test/configs2/settings.yaml
+++ b/example_test/configs2/settings.yaml
@@ -55,9 +55,9 @@ run_list:
     - sub_balancing.geography=TRACT
     - sub_balancing.geography=TAZ
     - expand_households
+    - summarize
     - write_tables
     - write_synthetic_population
-    - summarize
 
   # resume_after: write_results
 

--- a/populationsim/steps/summarize.py
+++ b/populationsim/steps/summarize.py
@@ -15,7 +15,7 @@ from populationsim.util import setting
 
 logger = logging.getLogger(__name__)
 
-AS_CSV = True
+AS_CSV = False
 
 
 def out_table(table_name, df):
@@ -30,6 +30,7 @@ def out_table(table_name, df):
         write_index = df.index.name is not None
         df.to_csv(file_path, index=write_index)
     else:
+        logger.info("saving summary table %s" % table_name)
         inject.add_table(table_name, df)
 
 

--- a/populationsim/tests/configs2/settings.yaml
+++ b/populationsim/tests/configs2/settings.yaml
@@ -43,6 +43,7 @@ output_tables:
   action: include
   tables:
     - expanded_household_ids
+    - summary_DISTRICT
 
 
 output_synthetic_population:

--- a/populationsim/tests/test_flex.py
+++ b/populationsim/tests/test_flex.py
@@ -50,7 +50,10 @@ def test_full_run2():
 
     assert isinstance(pipeline.get_table('expanded_household_ids'), pd.DataFrame)
 
+    # output tables list action: include
+    assert os.path.exists(os.path.join(output_dir, 'expanded_household_ids.csv'))
     assert os.path.exists(os.path.join(output_dir, 'summary_DISTRICT.csv'))
+    assert not os.path.exists(os.path.join(output_dir, 'summary_TAZ.csv'))
 
     # tables will no longer be available after pipeline is closed
     pipeline.close_pipeline()

--- a/populationsim/tests/test_steps.py
+++ b/populationsim/tests/test_steps.py
@@ -46,9 +46,9 @@ def test_full_run1():
         'sub_balancing.geography = TRACT',
         'sub_balancing.geography=TAZ',
         'expand_households',
-        'write_synthetic_population',
+        'summarize',
         'write_tables',
-        'summarize'
+        'write_synthetic_population',
     ]
 
     pipeline.run(models=_MODELS, resume_after=None)
@@ -59,6 +59,8 @@ def test_full_run1():
     assert len(taz_hh_counts) == TAZ_COUNT
     assert taz_hh_counts.loc[100] == TAZ_100_HH_COUNT
 
+    # output_tables action: skip
+    assert not os.path.exists(os.path.join(output_dir, 'households.csv'))
     assert os.path.exists(os.path.join(output_dir, 'summary_DISTRICT_1.csv'))
 
     # tables will no longer be available after pipeline is closed


### PR DESCRIPTION
adds summary tables to pipeline instead of writing them directly as csv files so user can use output_tables in settings to specify which ones to write.

This required reordering steps to run summary before write_tables in run_lists.

I also added summarize.repop to repop run list and print out the summary_TAZ table. It seemed useful. The only caveat is the other geography level summary tables (e.g. summary_TRACT) aren't meaningful for repop. Could remove the summary.repop call and summary_TAZ from output_tables if not desired for repop.