### PR TITLE
Handle utf-8 decoding error

### DIFF
--- a/populationsim/steps/input_pre_processor.py
+++ b/populationsim/steps/input_pre_processor.py
@@ -73,7 +73,7 @@ def input_pre_processor():
                                % (tablename, data_file_path, ))
 
         logger.info("Reading csv file %s" % data_file_path)
-        df = pd.read_csv(data_file_path, comment='#')
+        df = read_csv_with_fallback_encoding(data_file_path)
 
         logger.info("input file columns: %s" % df.columns.values)
 
@@ -123,3 +123,16 @@ def input_pre_processor():
         # add (or replace) pipeline table
         repop = inject.get_step_arg('repop', default=False)
         inject.add_table(tablename, df, replace=repop)
+
+
+def read_csv_with_fallback_encoding(filepath):
+    """read a CSV to a pandas DataFrame using default utf-8 encoding,
+    but try alternate Windows-compatible cp1252 if unicode fails
+
+    """
+    try:
+        return pd.read_csv(filepath, comment='#')
+    except UnicodeDecodeError:
+        logger.warning(
+            "Reading %s with default utf-8 encoding failed, trying cp1252 instead", filepath)
+        return pd.read_csv(filepath, comment='#', encoding='cp1252')


### PR DESCRIPTION
Fixes https://github.com/RSGInc/populationsim/issues/83

The input_pre_processor uses pandas.read_csv to read the input files, but the default utf-8 encoding throws an error for some types of Windows files. The cp1252 encoding handles most cases that utf-8 can't, so we should fallback to this alternate decoder when utf-8 fails.

This only fixes this issue for files read during the input_pre_processor step, and I had trouble creating an acceptable regression test, but I tested locally with the problem csv, and verified that this doesn't break anything for utf-8 encoded inputs.