### PR TITLE
fix coveralls compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - conda update -q conda
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION future
 - source activate test-environment
-- pip install pytest pytest-cov coveralls pycodestyle
+- conda install pytest pytest-cov coveralls pycodestyle
 - pip install .
 script:
 - pycodestyle populationsim


### PR DESCRIPTION
pipped versions of [coveralls](https://github.com/coveralls-clients/coveralls-python) use the wrong version of [coverage](https://github.com/nedbat/coveragepy) to generate the coverage report. conda installations seem to sort things out correctly.