### PR TITLE
Freeze ortools package below 7.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'activitysim >= 0.9.2',
         'numpy >= 1.16.1',
         'pandas >= 0.24.1',
-        'ortools >= 5.1.4045',
+        'ortools >= 5.1.4045, < 7.5',
         'future >= 0.16.0'
     ]
 )


### PR DESCRIPTION
[ortools 7.5](https://pypi.org/project/ortools/7.5.7466/) requires the [Visual Studio C++ redistributable](https://visualstudio.microsoft.com/downloads/?q=Redistributable) be installed on Windows 10. While many users are likely to have this already installed as part of their Visual Studio setup, we'd rather avoid additional dependencies to keep track of in the documentation for PopulationSim.

It's likely ortools will include all their precompiled binaries in a later release, so we'll exclude 7.5 from our package list until then.

closes https://github.com/ActivitySim/populationsim/issues/108